### PR TITLE
Change tabs to pages

### DIFF
--- a/src/components/EmbeddingExplorer.vue
+++ b/src/components/EmbeddingExplorer.vue
@@ -168,7 +168,13 @@
                 @right-click="onRightClickItem"/>
 
             <h3 v-else class="text-uppercase" :style="{ textAlign: 'center', width: size+'px' }">
-                NO {{ app.itemName }}s AVAILABLE
+                <div v-if="matrixE.length === 0">
+                    NO {{ app.itemName }}s AVAILABLE
+                </div>
+                <div v-else>
+                    <div>CALCULATING ..</div>
+                    <v-progress-circular indeterminate class="mt-2"></v-progress-circular>
+                </div>
             </h3>
 
             <v-divider v-if="app.hasMetaItems" vertical class="ml-2 mr-2"></v-divider>
@@ -202,7 +208,13 @@
                 @right-click="onRightClickExt"/>
 
             <h3 v-else-if="app.hasMetaItems" class="text-uppercase" :style="{ textAlign: 'center', width: size+'px' }">
-                NO {{ app.metaItemName }}s AVAILABLE
+                <div v-if="matrixE.length === 0">
+                    NO {{ app.metaItemName }}s AVAILABLE
+                </div>
+                <div v-else>
+                    <div>CALCULATING ..</div>
+                    <v-progress-circular indeterminate class="mt-2"></v-progress-circular>
+                </div>
             </h3>
 
             </div>
@@ -229,7 +241,7 @@
 </template>
 
 <script setup>
-    import { computed, onMounted, reactive, ref, watch } from 'vue';
+    import { computed, onMounted, reactive, ref, toRaw, watch } from 'vue';
     import * as d3 from 'd3';
     import * as druid from '@saehrimnir/druidjs';
     import ScatterPlot from './vis/ScatterPlot.vue';
@@ -241,9 +253,9 @@
     import { APP_URLS, useApp } from '@/store/app';
     import MiniDialog from './dialogs/MiniDialog.vue';
     import { FILTER_TYPES } from '@/use/filters';
-    import { getMetric } from '@/use/metrics';
     import { useToast } from 'vue-toastification';
     import Cookies from 'js-cookie';
+    import MyWorker from '@/worker/dr-worker?worker'
 
     const tt = useTooltip();
     const settings = useSettings()
@@ -297,8 +309,8 @@
     const selColorG = ref([])
     const selColorE = ref([])
 
-    let matrixG, dataG;
-    let matrixE, dataE;
+    let matrixG = [], dataG, gWorker;
+    let matrixE = [], dataE, eWorker;
 
     const gameMap = new Map();
     const extMap = new Map();
@@ -341,7 +353,7 @@
             })
             p[i] = arr;
         });
-        matrixG = dataG.length > 0 ? druid.Matrix.from(p) : []
+        matrixG = p // dataG.length > 0 ? druid.Matrix.from(p) : []
     }
     function readExts() {
         if (!app.hasMetaItems) {
@@ -409,31 +421,7 @@
             p[i] = arr;
         });
 
-        matrixE = dataE.length > 0 ? druid.Matrix.from(p) : []
-    }
-
-    function getDR(which="items") {
-        const params = Object.assign({}, which == "items" ? defaultsG : defaultsE)
-        Cookies.set(which == "items" ? "ee-settings-g" : "ee-settings-e", JSON.stringify(params), { expires: 365 })
-        params.metric = getMetric(params.metric)
-        const method = params.method;
-        delete params.method
-        const matrix = which == "items" ? matrixG : matrixE;
-
-        if (!matrix || matrix.length === 0) {
-            console.warn("empty matrix")
-            return;
-        }
-
-        const DR = druid[method]
-        switch (method) {
-            // case "ISOMAP": return new DR(matrix, { metric: druid.cosine })
-            case "TopoMap": return new DR(matrix, params)
-            case "MDS": return new DR(matrix, params)
-            case "TSNE": return new DR(matrix, params)
-            case "UMAP": return new DR(matrix, params)
-            default: return new DR(matrix)
-        }
+        matrixE = p //dataE.length > 0 ? druid.Matrix.from(p) : []
     }
 
     function calculateDR() {
@@ -459,15 +447,33 @@
         if (paramsG.value) Object.assign(defaultsG, paramsG.value.getParams())
         if (notify) toast.info("calculating items embedding")
 
-        const dr = getDR("items")
-        if (!dr) return
-        const trans = Array.from(dr.transform())
-        pointsG.value = trans.map((d,i) => {
-            const game = dataG[i]
-            const val = getColorG(game)
-            return [d[0], d[1], i, APP_URLS.TEASER+game.teaser, val]
-        })
-        refreshG.value = Date.now();
+        if (!matrixG || matrixG.length === 0) {
+            console.warn("empty matrix")
+            return;
+        }
+
+        const params = Object.assign({}, defaultsG)
+        Cookies.set("ee-settings-g", JSON.stringify(params), { expires: 365 })
+
+        if (gWorker) {
+            gWorker.terminate()
+        }
+
+        gWorker = new MyWorker();
+        // set map upon completion
+        gWorker.onmessage = e => {
+            console.log("received message from worker")
+            gWorker = null
+            pointsG.value = e.data.map((d,i) => {
+                const game = dataG[i]
+                const val = getColorG(game)
+                return [d[0], d[1], i, APP_URLS.TEASER+game.teaser, val]
+            })
+            refreshG.value = Date.now();
+        }
+        // compute feature maps in web worker
+        gWorker.postMessage({ params: params, matrix: matrixG })
+        console.log("started worker for items")
 
         // console.log(trans.map((d, i) => {
         //     const game = dataG[i]
@@ -498,15 +504,36 @@
             default: return 1;
         }
     }
+
     function calculateExtsDR(notify=false) {
         if (paramsE.value) Object.assign(defaultsE, paramsE.value.getParams())
         if (notify) toast.info("calculating embedding")
 
-        const dr = getDR("evidence");
-        if (!dr) return
-        pointsE.value = Array.from(dr.transform()).map((d,i) => ([d[0], d[1], i, getColorE(dataE[i])]))
-        refreshE.value = Date.now();
+        if (!matrixE || matrixE.length === 0) {
+            console.warn("empty matrix")
+            return;
+        }
+
+        const params = Object.assign({}, defaultsE)
+        Cookies.set("ee-settings-e", JSON.stringify(params), { expires: 365 })
+
+        if (eWorker) {
+            eWorker.terminate()
+        }
+
+        eWorker = new MyWorker();
+        // set map upon completion
+        eWorker.onmessage = e => {
+            console.log("received message from worker")
+            eWorker = null
+            pointsE.value = e.data.map((d,i) => ([d[0], d[1], i, getColorE(dataE[i])]))
+            refreshE.value = Date.now();
+        }
+        // compute feature maps in web worker
+        eWorker.postMessage({ params: params, matrix: matrixE })
+        console.log("started worker for meta_items")
     }
+
     function updateColorE() {
         pointsE.value.forEach((d,i) => {
             const item = dataE[i]

--- a/src/components/EmbeddingExplorer.vue
+++ b/src/components/EmbeddingExplorer.vue
@@ -462,7 +462,6 @@
         gWorker = new MyWorker();
         // set map upon completion
         gWorker.onmessage = e => {
-            console.log("received message from worker")
             gWorker = null
             pointsG.value = e.data.map((d,i) => {
                 const game = dataG[i]
@@ -473,7 +472,6 @@
         }
         // compute feature maps in web worker
         gWorker.postMessage({ params: params, matrix: matrixG })
-        console.log("started worker for items")
 
         // console.log(trans.map((d, i) => {
         //     const game = dataG[i]
@@ -524,14 +522,12 @@
         eWorker = new MyWorker();
         // set map upon completion
         eWorker.onmessage = e => {
-            console.log("received message from worker")
             eWorker = null
             pointsE.value = e.data.map((d,i) => ([d[0], d[1], i, getColorE(dataE[i])]))
             refreshE.value = Date.now();
         }
         // compute feature maps in web worker
         eWorker.postMessage({ params: params, matrix: matrixE })
-        console.log("started worker for meta_items")
     }
 
     function updateColorE() {

--- a/src/components/MiniNavBar.vue
+++ b/src/components/MiniNavBar.vue
@@ -697,10 +697,10 @@
     }
 
     function goImport() {
-        router.replace("/import")
+        router.push("/import")
     }
     function goExport() {
-        router.replace("/export")
+        router.push("/export")
     }
 
     onMounted(function() {

--- a/src/components/NavLink.vue
+++ b/src/components/NavLink.vue
@@ -1,12 +1,14 @@
 <template>
-    <div v-if="games.activeGame !== null" class="navlink nonav">
-        <v-icon class="mr-1" :icon="settings.tabIcons[to]"/>
-        <span v-if="showTabNames">{{ settings.tabNames[to] }}</span>
+    <div class="pb-1 pt-1">
+        <div v-if="games.activeGame !== null"  class="navlink nonav">
+            <v-icon :icon="settings.tabIcons[to]"/>
+            <span v-if="showTabNames" class="ml-1">{{ settings.tabNames[to] }}</span>
+        </div>
+        <RouterLink v-else :to="to" :class="['navlink', activeTab === to ? 'nav-active' : '']">
+            <v-icon :icon="settings.tabIcons[to]"/>
+            <span v-if="showTabNames" class="ml-1">{{ settings.tabNames[to] }}</span>
+        </RouterLink>
     </div>
-    <RouterLink v-else :to="to" :class="['navlink', activeTab === to ? 'nav-active' : '']">
-        <v-icon class="mr-1" :icon="settings.tabIcons[to]"/>
-        <span v-if="showTabNames">{{ settings.tabNames[to] }}</span>
-    </RouterLink>
 </template>
 
 <script setup>

--- a/src/components/NavLink.vue
+++ b/src/components/NavLink.vue
@@ -1,0 +1,55 @@
+<template>
+    <div v-if="games.activeGame !== null" class="navlink nonav">
+        <v-icon class="mr-1" :icon="settings.tabIcons[to]"/>
+        <span v-if="showTabNames">{{ settings.tabNames[to] }}</span>
+    </div>
+    <RouterLink v-else :to="to" :class="['navlink', activeTab === to ? 'nav-active' : '']">
+        <v-icon class="mr-1" :icon="settings.tabIcons[to]"/>
+        <span v-if="showTabNames">{{ settings.tabNames[to] }}</span>
+    </RouterLink>
+</template>
+
+<script setup>
+    import { useGames } from '@/store/games';
+    import { useSettings } from '@/store/settings';
+    import { useWindowSize } from '@vueuse/core';
+    import { storeToRefs } from 'pinia';
+    import { computed } from 'vue';
+
+    const games = useGames()
+    const settings = useSettings()
+    const { activeTab } = storeToRefs(settings)
+
+    const wSize = useWindowSize()
+    const showTabNames = computed(() => wSize.width.value > 1400)
+
+    const props = defineProps({
+        to: {
+            type: String,
+            required: true
+        }
+    })
+</script>
+
+<style scoped>
+.navlink, .navlink:visited {
+    color: white;
+    text-transform: uppercase;
+    text-decoration: none;
+    padding: 4px 8px;
+    cursor: pointer;
+}
+
+.navlink.nonav {
+    color: grey;
+    cursor: not-allowed;
+}
+
+.navlink:not(.nonav):hover {
+    background-color: #666;
+}
+
+.nav-active * {
+    color: #0ad39f;
+}
+</style>

--- a/src/components/evidence/EvidenceHeatmap.vue
+++ b/src/components/evidence/EvidenceHeatmap.vue
@@ -152,7 +152,7 @@
     import { onMounted, reactive, watch } from 'vue';
     import BarCode from '../vis/BarCode.vue';
     import { CTXT_OPTIONS, useSettings } from '@/store/settings';
-    import { useApp } from '@/store/app';
+    import { APP_URLS, useApp } from '@/store/app';
     import { pointer, rgb } from 'd3';
     import { useTooltip } from '@/store/tooltip';
     import { sortObjByString } from '@/use/sorting';

--- a/src/components/games/WhoAmI.vue
+++ b/src/components/games/WhoAmI.vue
@@ -306,7 +306,7 @@
     import DM from '@/use/data-manager';
     import { useElementSize, useWindowSize } from '@vueuse/core';
     import TreeMap from '../vis/TreeMap.vue';
-    import { OBJECTION_ACTIONS, useApp } from '@/store/app';
+    import { OBJECTION_ACTIONS, useApp, APP_URLS } from '@/store/app';
     import { POSITION, useToast } from 'vue-toastification';
     import { useTooltip } from '@/store/tooltip';
     import BarCode from '../vis/BarCode.vue';
@@ -382,7 +382,7 @@
 
     const imageWidth = computed(() => Math.max(80, Math.floor(itemsWidth.value / 4)-15))
     const itemsWidth = computed(() => {
-        const mul = wSize.width.value <= 1600 ? 0.25 : 0.3
+        const mul = wSize.width.value <= 1600 ? 0.2 : 0.25
         return Math.max(300, elSize.width.value * mul)
     })
     const treeWidth = computed(() => Math.max(400, elSize.width.value - itemsWidth.value - 50))

--- a/src/components/tags/TagText.vue
+++ b/src/components/tags/TagText.vue
@@ -7,7 +7,7 @@
         @pointermove="onHover"
         @pointerleave="onLeave"
         >
-        {{ tagObj.name }}
+        {{ tagObj ? tagObj.name : '?' }}
     </span>
 </template>
 

--- a/src/components/vis/BarCode.vue
+++ b/src/components/vis/BarCode.vue
@@ -271,7 +271,7 @@
 
             ctx.fillStyle = isSelected ? selColor.value :
                 props.binary ?
-                    binCol.value : (getV(d) !== props.noValue ? color(getV(d))
+                    binCol.value : (getV(d) !== props.noValue && color ? color(getV(d))
                 : noCol.value
             );
             ctx.fillRect(

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -141,13 +141,7 @@
                 break;
             case "explore_meta":
                 if (ds.value && !hasMetaItems.value) {
-                    activeTab.value = "coding"
-                    showBarCodes.value = true;
-                    showScatter.value = false;
-                    showEvidenceTiles.value = false;
-                    showTable.value = true;
-                    showExtTiles.value = false;
-                    return
+                    return router.push("/coding")
                 }
                 showBarCodes.value = false;
                 showScatter.value = true;
@@ -217,10 +211,6 @@
                 app.setActiveCode(code.id)
             }
         }
-
-        if (route.query.tab && settings.tabNames[route.query.tab]) {
-            router.push("/"+route.query.tab)
-        }
     }
 
     function checkDataset() {
@@ -239,9 +229,13 @@
 
     onMounted(() => {
         if (route.path.length <= 1) {
-            const startPage = Cookies.get("start-page")
-            if (startPage) {
-                router.push("/"+startPage)
+            if (route.query.tab && settings.tabNames[route.query.tab]) {
+                router.push("/"+route.query.tab)
+            } else {
+                const startPage = Cookies.get("start-page")
+                if (startPage) {
+                    router.push("/"+startPage)
+                }
             }
         } else {
             activeTab.value = route.path.slice(1)

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -3,7 +3,7 @@
         <ActionContextMenu/>
         <GlobalShortcuts/>
 
-        <nav class="topnav d-flex align-center justify-center">
+        <nav class="topnav d-flex align-stretch justify-center">
             <NavLink to="coding"/>
             <NavLink to="objections"/>
             <NavLink to="agree"/>

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -3,54 +3,46 @@
         <ActionContextMenu/>
         <GlobalShortcuts/>
 
-        <v-tabs v-model="activeTab"
-            :disabled="games.activeGame !== null"
-            class="main-tabs"
-            color="secondary"
-            bg-color="surface-variant"
-            align-tabs="center"
-            density="compact"
-            @update:model-value="checkReload"
-            >
-            <v-tab value="coding">
-                <v-icon class="mr-1" :color="activeTab === 'coding' ? 'secondary' : 'default'" :icon="settings.tabIcons['coding']"/>
+        <nav class="topnav d-flex align-center justify-center">
+            <RouterLink to="coding" :class="['navlink', activeTab === 'coding' ? 'nav-active' : '']">
+                <v-icon class="mr-1" :icon="settings.tabIcons['coding']"/>
                 <span v-if="showTabNames">{{ settings.tabNames["coding"] }}</span>
-            </v-tab>
-            <v-tab value="objections">
-                <v-icon class="mr-1" :color="activeTab === 'objections' ? 'secondary' : 'default'" :icon="settings.tabIcons['objections']"/>
+            </RouterLink>
+            <RouterLink to="objections" :class="['navlink', activeTab === 'objections' ? 'nav-active' : '']">
+                <v-icon class="mr-1" :icon="settings.tabIcons['objections']"/>
                 <span v-if="showTabNames">{{ settings.tabNames["objections"] }}</span>
-            </v-tab>
-            <v-tab value="agree">
-                <v-icon class="mr-1" :color="activeTab === 'agree' ? 'secondary' : 'default'" :icon="settings.tabIcons['agree']"/>
+            </RouterLink>
+            <RouterLink to="agree" :class="['navlink', activeTab === 'agree' ? 'nav-active' : '']">
+                <v-icon class="mr-1" :icon="settings.tabIcons['agree']"/>
                 <span v-if="showTabNames">{{ settings.tabNames["agree"] }}</span>
-            </v-tab>
-            <v-tab value="transition">
-                <v-icon class="mr-1" :color="activeTab === 'transition' ? 'secondary' : 'default'" :icon="settings.tabIcons['transition']"/>
+            </RouterLink>
+            <RouterLink to="transition" :class="['navlink', activeTab === 'transition' ? 'nav-active' : '']">
+                <v-icon class="mr-1" :icon="settings.tabIcons['transition']"/>
                 <span v-if="showTabNames">{{ settings.tabNames["transition"] }}</span>
-            </v-tab>
+            </RouterLink>
 
-            <v-divider vertical thickness="2" color="primary" class="ml-1 mr-1" opacity="1"></v-divider>
+            <v-divider vertical thickness="2" color="primary" opacity="1" class="ml-1 mr-1"></v-divider>
 
-            <v-tab value="games">
-                <v-icon class="mr-1" :color="activeTab === 'games' ? 'secondary' : 'default'" :icon="settings.tabIcons['games']"/>
+            <RouterLink to="games" :class="['navlink', activeTab === 'games' ? 'nav-active' : '']">
+                <v-icon class="mr-1" :icon="settings.tabIcons['games']"/>
                 <span v-if="showTabNames">{{ settings.tabNames["games"] }}</span>
-            </v-tab>
+            </RouterLink>
 
             <v-divider vertical thickness="2" color="primary" class="ml-1 mr-1" opacity="1"></v-divider>
 
-            <v-tab value="explore_tags">
-                <v-icon class="mr-1" :color="activeTab === 'explore_tags' ? 'secondary' : 'default'" :icon="settings.tabIcons['explore_tags']"/>
+            <RouterLink to="explore_tags" :class="['navlink', activeTab === 'explore_tags' ? 'nav-active' : '']">
+                <v-icon class="mr-1" :icon="settings.tabIcons['explore_tags']"/>
                 <span v-if="showTabNames">{{ settings.tabNames["explore_tags"] }}</span>
-            </v-tab>
-            <v-tab value="explore_ev">
-                <v-icon class="mr-1" :color="activeTab === 'explore_ev' ? 'secondary' : 'default'" :icon="settings.tabIcons['explore_ev']"/>
+            </RouterLink>
+            <RouterLink to="explore_ev" :class="['navlink', activeTab === 'explore_ev' ? 'nav-active' : '']">
+                <v-icon class="mr-1" :icon="settings.tabIcons['explore_ev']"/>
                 <span v-if="showTabNames">{{ settings.tabNames["explore_ev"] }}</span>
-            </v-tab>
-            <v-tab v-if="hasMetaItems" value="explore_meta">
-                <v-icon class="mr-1" :color="activeTab === 'explore_meta' ? 'secondary' : 'default'" :icon="settings.tabIcons['explore_meta']"/>
+            </RouterLink>
+            <RouterLink v-if="hasMetaItems" to="explore_meta" :class="['navlink', activeTab === 'explore_meta' ? 'nav-active' : '']">
+                <v-icon class="mr-1" :icon="settings.tabIcons['explore_meta']"/>
                 <span v-if="showTabNames">{{ settings.tabNames["explore_meta"] }}</span>
-            </v-tab>
-        </v-tabs>
+            </RouterLink>
+        </nav>
 
         <div ref="el" style="width: 100%;">
 
@@ -62,42 +54,11 @@
                     <ItemBarCodes :hidden="!showBarCodes"/>
                 </div>
 
-                <v-tabs-window v-model="activeTab">
-
-                    <v-tabs-window-item value="transition">
-                        <TransitionView v-if="activeUserId !== null" :loading="isLoading"/>
-                    </v-tabs-window-item>
-
-                    <v-tabs-window-item value="agree">
-                        <AgreementView v-if="activeUserId !== null" :loading="isLoading"/>
-                    </v-tabs-window-item>
-
-                    <v-tabs-window-item value="objections">
-                        <ObjectionView v-if="activeUserId !== null" :loading="isLoading"/>
-                    </v-tabs-window-item>
-
-                    <v-tabs-window-item value="games">
-                        <GamesView v-if="activeUserId !== null" :loading="isLoading"/>
-                    </v-tabs-window-item>
-
-                    <v-tabs-window-item value="explore_meta">
-                        <ExploreExtView v-if="activeUserId !== null" :loading="isLoading"/>
-                    </v-tabs-window-item>
-
-                    <v-tabs-window-item value="explore_tags">
-                        <ExploreTagsView v-if="activeUserId !== null" :loading="isLoading"/>
-                    </v-tabs-window-item>
-
-                    <v-tabs-window-item value="explore_ev">
-                        <ExploreEvidenceView v-if="activeUserId !== null" :loading="isLoading"/>
-                    </v-tabs-window-item>
-
-                </v-tabs-window>
-
-
                 <div class="d-flex justify-center">
                     <EmbeddingExplorer :hidden="!showScatter" :width="Math.max(400,width*0.8)"/>
                 </div>
+
+                <router-view/>
 
                 <v-sheet class="mt-2 pa-2">
                     <RawDataView
@@ -145,7 +106,7 @@
     import { useTimes } from '@/store/times';
     import { loadCodesByDataset, loadCodeTransitionsByDataset } from '@/use/data-api';
     import DM from '@/use/data-manager';
-    import { useRoute } from 'vue-router';
+    import { useRoute, useRouter } from 'vue-router';
     import { useTooltip } from '@/store/tooltip';
     import GamesView from '@/components/views/GamesView.vue';
     import { useGames } from '@/store/games';
@@ -155,7 +116,6 @@
     const times = useTimes()
     const route = useRoute()
     const tt = useTooltip()
-    const games = useGames()
 
     const {
         ds,
@@ -180,6 +140,8 @@
 
     const el = ref(null)
     const { width } = useElementSize(el)
+
+    const router = useRouter()
 
     const wSize = useWindowSize()
 
@@ -289,10 +251,8 @@
             }
         }
 
-        if (route.query.tab) {
-            if (settings.tabNames[route.query.tab]) {
-                activeTab.value = route.query.tab
-            }
+        if (route.query.tab && settings.tabNames[route.query.tab]) {
+            router.replace("/"+route.query.tab)
         }
     }
 
@@ -311,9 +271,13 @@
     }
 
     onMounted(() => {
-        const startPage = Cookies.get("start-page")
-        if (startPage) {
-            settings.activeTab = startPage;
+        if (route.path.length <= 1) {
+            const startPage = Cookies.get("start-page")
+            if (startPage) {
+                router.replace("/"+startPage)
+            }
+        } else {
+            activeTab.value = route.path.slice(1)
         }
         checkDataset()
         checkReload()
@@ -369,10 +333,42 @@
         });
     }
 
+    watch(() => route.path, function() {
+        const tab = route.path.slice(1)
+        if (tab) {
+            activeTab.value = tab
+            checkReload()
+        }
+    })
+
 
 </script>
 
 <style scoped>
+.topnav {
+    background-color: #333;
+    position: sticky;
+    top:0;
+    left:0;
+    width: 100vw;
+    z-index: 4999;
+    font-size: smaller;
+}
+.navlink, .navlink:visited {
+    color: white;
+    text-transform: uppercase;
+    text-decoration: none;
+    padding: 4px 8px;
+}
+
+.navlink:hover {
+    background-color: #666;
+}
+
+.nav-active * {
+    color: #0ad39f;
+}
+
 .main-tabs {
     position: sticky;
     top: 0;

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -4,44 +4,20 @@
         <GlobalShortcuts/>
 
         <nav class="topnav d-flex align-center justify-center">
-            <RouterLink to="coding" :class="['navlink', activeTab === 'coding' ? 'nav-active' : '']">
-                <v-icon class="mr-1" :icon="settings.tabIcons['coding']"/>
-                <span v-if="showTabNames">{{ settings.tabNames["coding"] }}</span>
-            </RouterLink>
-            <RouterLink to="objections" :class="['navlink', activeTab === 'objections' ? 'nav-active' : '']">
-                <v-icon class="mr-1" :icon="settings.tabIcons['objections']"/>
-                <span v-if="showTabNames">{{ settings.tabNames["objections"] }}</span>
-            </RouterLink>
-            <RouterLink to="agree" :class="['navlink', activeTab === 'agree' ? 'nav-active' : '']">
-                <v-icon class="mr-1" :icon="settings.tabIcons['agree']"/>
-                <span v-if="showTabNames">{{ settings.tabNames["agree"] }}</span>
-            </RouterLink>
-            <RouterLink to="transition" :class="['navlink', activeTab === 'transition' ? 'nav-active' : '']">
-                <v-icon class="mr-1" :icon="settings.tabIcons['transition']"/>
-                <span v-if="showTabNames">{{ settings.tabNames["transition"] }}</span>
-            </RouterLink>
+            <NavLink to="coding"/>
+            <NavLink to="objections"/>
+            <NavLink to="agree"/>
+            <NavLink to="transition"/>
 
             <v-divider vertical thickness="2" color="primary" opacity="1" class="ml-1 mr-1"></v-divider>
 
-            <RouterLink to="games" :class="['navlink', activeTab === 'games' ? 'nav-active' : '']">
-                <v-icon class="mr-1" :icon="settings.tabIcons['games']"/>
-                <span v-if="showTabNames">{{ settings.tabNames["games"] }}</span>
-            </RouterLink>
+            <NavLink to="games"/>
 
             <v-divider vertical thickness="2" color="primary" class="ml-1 mr-1" opacity="1"></v-divider>
 
-            <RouterLink to="explore_tags" :class="['navlink', activeTab === 'explore_tags' ? 'nav-active' : '']">
-                <v-icon class="mr-1" :icon="settings.tabIcons['explore_tags']"/>
-                <span v-if="showTabNames">{{ settings.tabNames["explore_tags"] }}</span>
-            </RouterLink>
-            <RouterLink to="explore_ev" :class="['navlink', activeTab === 'explore_ev' ? 'nav-active' : '']">
-                <v-icon class="mr-1" :icon="settings.tabIcons['explore_ev']"/>
-                <span v-if="showTabNames">{{ settings.tabNames["explore_ev"] }}</span>
-            </RouterLink>
-            <RouterLink v-if="hasMetaItems" to="explore_meta" :class="['navlink', activeTab === 'explore_meta' ? 'nav-active' : '']">
-                <v-icon class="mr-1" :icon="settings.tabIcons['explore_meta']"/>
-                <span v-if="showTabNames">{{ settings.tabNames["explore_meta"] }}</span>
-            </RouterLink>
+            <NavLink to="explore_tags"/>
+            <NavLink to="explore_ev"/>
+            <NavLink v-if="hasMetaItems" to="explore_meta"/>
         </nav>
 
         <div ref="el" style="width: 100%;">
@@ -54,11 +30,11 @@
                     <ItemBarCodes :hidden="!showBarCodes"/>
                 </div>
 
+                <router-view/>
+
                 <div class="d-flex justify-center">
                     <EmbeddingExplorer :hidden="!showScatter" :width="Math.max(400,width*0.8)"/>
                 </div>
-
-                <router-view/>
 
                 <v-sheet class="mt-2 pa-2">
                     <RawDataView
@@ -83,39 +59,34 @@
 <script setup>
 
     import { useApp } from '@/store/app'
-    import TransitionView from '@/components/views/TransitionView.vue'
-    import ExploreTagsView from '@/components/views/ExploreTagsView.vue';
     import { storeToRefs } from 'pinia'
     import { computed, onMounted, ref, watch } from 'vue'
     import GlobalShortcuts from '@/components/GlobalShortcuts.vue';
     import ItemEvidenceTiles from '@/components/evidence/ItemEvidenceTiles.vue';
     import RawDataView from '@/components/RawDataView.vue';
     import MetaItemsList from '@/components/meta_items/MetaItemsList.vue';
-    import ObjectionView from '@/components/views/ObjectionView.vue';
 
     import { useSettings } from '@/store/settings';
     import MiniNavBar from '@/components/MiniNavBar.vue';
     import ItemBarCodes from '@/components/items/ItemBarCodes.vue';
     import EmbeddingExplorer from '@/components/EmbeddingExplorer.vue';
     import { useElementSize, useWindowSize } from '@vueuse/core';
-    import ExploreExtView from '@/components/views/ExploreExtView.vue';
     import ActionContextMenu from '@/components/dialogs/ActionContextMenu.vue';
-    import AgreementView from '@/components/views/AgreementView.vue';
-    import ExploreEvidenceView from '@/components/views/ExploreEvidenceView.vue';
     import Cookies from 'js-cookie';
     import { useTimes } from '@/store/times';
     import { loadCodesByDataset, loadCodeTransitionsByDataset } from '@/use/data-api';
     import DM from '@/use/data-manager';
     import { useRoute, useRouter } from 'vue-router';
     import { useTooltip } from '@/store/tooltip';
-    import GamesView from '@/components/views/GamesView.vue';
     import { useGames } from '@/store/games';
+    import NavLink from '@/components/NavLink.vue';
 
     const settings = useSettings();
     const app = useApp()
     const times = useTimes()
     const route = useRoute()
     const tt = useTooltip()
+    const games = useGames()
 
     const {
         ds,
@@ -142,10 +113,6 @@
     const { width } = useElementSize(el)
 
     const router = useRouter()
-
-    const wSize = useWindowSize()
-
-    const showTabNames = computed(() => wSize.width.value > 1400)
 
     function checkReload() {
         window.scrollTo(0, 0)
@@ -252,7 +219,7 @@
         }
 
         if (route.query.tab && settings.tabNames[route.query.tab]) {
-            router.replace("/"+route.query.tab)
+            router.push("/"+route.query.tab)
         }
     }
 
@@ -274,7 +241,7 @@
         if (route.path.length <= 1) {
             const startPage = Cookies.get("start-page")
             if (startPage) {
-                router.replace("/"+startPage)
+                router.push("/"+startPage)
             }
         } else {
             activeTab.value = route.path.slice(1)
@@ -353,20 +320,6 @@
     width: 100vw;
     z-index: 4999;
     font-size: smaller;
-}
-.navlink, .navlink:visited {
-    color: white;
-    text-transform: uppercase;
-    text-decoration: none;
-    padding: 4px 8px;
-}
-
-.navlink:hover {
-    background-color: #666;
-}
-
-.nav-active * {
-    color: #0ad39f;
 }
 
 .main-tabs {

--- a/src/pages/index/agree.vue
+++ b/src/pages/index/agree.vue
@@ -1,0 +1,16 @@
+<template>
+    <AgreementView v-if="activeUserId !== null" :loading="isLoading"/>
+</template>
+
+<script setup>
+    import AgreementView from '@/components/views/AgreementView.vue';
+    import { useApp } from '@/store/app';
+    import { useSettings } from '@/store/settings';
+    import { storeToRefs } from 'pinia';
+
+    const app = useApp()
+    const settings = useSettings()
+
+    const { activeUserId } = storeToRefs(app)
+    const { isLoading } = storeToRefs(settings)
+</script>

--- a/src/pages/index/coding.vue
+++ b/src/pages/index/coding.vue
@@ -1,0 +1,2 @@
+<template>
+</template>

--- a/src/pages/index/explore_ev.vue
+++ b/src/pages/index/explore_ev.vue
@@ -1,0 +1,16 @@
+<template>
+    <ExploreEvidenceView v-if="activeUserId !== null" :loading="isLoading"/>
+</template>
+
+<script setup>
+    import ExploreEvidenceView from '@/components/views/ExploreEvidenceView.vue';
+    import { useApp } from '@/store/app';
+    import { useSettings } from '@/store/settings';
+    import { storeToRefs } from 'pinia';
+
+    const app = useApp()
+    const settings = useSettings()
+
+    const { activeUserId } = storeToRefs(app)
+    const { isLoading } = storeToRefs(settings)
+</script>

--- a/src/pages/index/explore_meta.vue
+++ b/src/pages/index/explore_meta.vue
@@ -1,0 +1,16 @@
+<template>
+    <ExploreExtView v-if="activeUserId !== null" :loading="isLoading"/>
+</template>
+
+<script setup>
+    import ExploreExtView from '@/components/views/ExploreExtView.vue';
+    import { useApp } from '@/store/app';
+    import { useSettings } from '@/store/settings';
+    import { storeToRefs } from 'pinia';
+
+    const app = useApp()
+    const settings = useSettings()
+
+    const { activeUserId } = storeToRefs(app)
+    const { isLoading } = storeToRefs(settings)
+</script>

--- a/src/pages/index/explore_tags.vue
+++ b/src/pages/index/explore_tags.vue
@@ -1,0 +1,16 @@
+<template>
+    <ExploreTagsView v-if="activeUserId !== null" :loading="isLoading"/>
+</template>
+
+<script setup>
+    import ExploreTagsView from '@/components/views/ExploreTagsView.vue';
+    import { useApp } from '@/store/app';
+    import { useSettings } from '@/store/settings';
+    import { storeToRefs } from 'pinia';
+
+    const app = useApp()
+    const settings = useSettings()
+
+    const { activeUserId } = storeToRefs(app)
+    const { isLoading } = storeToRefs(settings)
+</script>

--- a/src/pages/index/games.vue
+++ b/src/pages/index/games.vue
@@ -1,0 +1,16 @@
+<template>
+    <GamesView v-if="activeUserId !== null" :loading="isLoading"/>
+</template>
+
+<script setup>
+    import GamesView from '@/components/views/GamesView.vue';
+    import { useApp } from '@/store/app';
+    import { useSettings } from '@/store/settings';
+    import { storeToRefs } from 'pinia';
+
+    const app = useApp()
+    const settings = useSettings()
+
+    const { activeUserId } = storeToRefs(app)
+    const { isLoading } = storeToRefs(settings)
+</script>

--- a/src/pages/index/index.vue
+++ b/src/pages/index/index.vue
@@ -1,0 +1,1 @@
+<template></template>

--- a/src/pages/index/objections.vue
+++ b/src/pages/index/objections.vue
@@ -1,0 +1,16 @@
+<template>
+    <ObjectionView v-if="activeUserId !== null" :loading="isLoading"/>
+</template>
+
+<script setup>
+    import ObjectionView from '@/components/views/ObjectionView.vue';
+    import { useApp } from '@/store/app';
+    import { useSettings } from '@/store/settings';
+    import { storeToRefs } from 'pinia';
+
+    const app = useApp()
+    const settings = useSettings()
+
+    const { activeUserId } = storeToRefs(app)
+    const { isLoading } = storeToRefs(settings)
+</script>

--- a/src/pages/index/transition.vue
+++ b/src/pages/index/transition.vue
@@ -1,0 +1,16 @@
+<template>
+    <TransitionView v-if="activeUserId !== null" :loading="isLoading"/>
+</template>
+
+<script setup>
+    import TransitionView from '@/components/views/TransitionView.vue';
+    import { useApp } from '@/store/app';
+    import { useSettings } from '@/store/settings';
+    import { storeToRefs } from 'pinia';
+
+    const app = useApp()
+    const settings = useSettings()
+
+    const { activeUserId } = storeToRefs(app)
+    const { isLoading } = storeToRefs(settings)
+</script>

--- a/src/store/settings.js
+++ b/src/store/settings.js
@@ -224,6 +224,20 @@ export const useSettings = defineStore('settings', {
                 objections: "mdi-exclamation-thick"
             }
         },
+        tabDesc: () => {
+            const app = useApp()
+            const meta = app.metaItemName ? app.metaItemName+"s" : "?"
+            return {
+                explore_meta: "explore "+meta,
+                explore_tags: "explore tags",
+                explore_ev: "explore evidence",
+                transition: "create and analyze transitions",
+                agree: "analyze and resolve inter-coder disagreement",
+                coding: "where you do the coding",
+                games: "validate your coding with games",
+                objections: "list of all objections"
+            }
+        }
     },
 
     actions: {

--- a/src/styles/settings.scss
+++ b/src/styles/settings.scss
@@ -75,12 +75,12 @@ $v-theme-info: #1976D2;
 }
 
 .v-theme--customLight .tthover {
-  background-color: #EEEEEE;
+  background-color: #fff;
   border: 1px solid #ddd;
   color: black;
 }
 .v-theme--customDark .tthover {
-  background-color: #333333;
+  background-color: #000;
   border: 1px solid #444;
   color: white;
 }

--- a/src/worker/dr-worker.js
+++ b/src/worker/dr-worker.js
@@ -1,0 +1,31 @@
+import { getMetric } from '@/use/metrics';
+import * as druid from '@saehrimnir/druidjs';
+
+onmessage = (e) => {
+    console.log("Message received from main script");
+    const dr = getDR(e.data.params, e.data.matrix)
+    postMessage(Array.from(dr.transform()));
+};
+
+function getDR(params, data) {
+    params.metric = getMetric(params.metric)
+    const method = params.method;
+    delete params.method
+
+    if (!data || data.length === 0) {
+        console.warn("empty matrix")
+        return;
+    }
+
+    const matrix = druid.Matrix.from(data)
+
+    const DR = druid[method]
+    switch (method) {
+        // case "ISOMAP": return new DR(matrix, { metric: druid.cosine })
+        case "TopoMap": return new DR(matrix, params)
+        case "MDS": return new DR(matrix, params)
+        case "TSNE": return new DR(matrix, params)
+        case "UMAP": return new DR(matrix, params)
+        default: return new DR(matrix)
+    }
+}

--- a/src/worker/dr-worker.js
+++ b/src/worker/dr-worker.js
@@ -2,7 +2,6 @@ import { getMetric } from '@/use/metrics';
 import * as druid from '@saehrimnir/druidjs';
 
 onmessage = (e) => {
-    console.log("Message received from main script");
     const dr = getDR(e.data.params, e.data.matrix)
     postMessage(Array.from(dr.transform()));
 };

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -2,7 +2,6 @@
 import AutoImport from 'unplugin-auto-import/vite'
 import Components from 'unplugin-vue-components/vite'
 import Fonts from 'unplugin-fonts/vite'
-import Pages from 'vite-plugin-pages'
 import Layouts from 'vite-plugin-vue-layouts'
 import Vue from '@vitejs/plugin-vue'
 import VueRouter from 'unplugin-vue-router/vite'
@@ -20,15 +19,12 @@ export const BASE_PATH = config.APP_BASE_PATH
 export default defineConfig({
     base: BASE_PATH,
     plugins: [
-    VueRouter(),
+    VueRouter({
+      src: 'src/pages',
+      path: BASE_PATH,
+    }),
     Vue({
       template: { transformAssetUrls }
-    }),
-    Pages({
-      // basic
-      dirs: [{ dir: 'src/pages', baseRoute: 'collacode' }],
-      extensions: ['vue', 'md'],
-      syncIndex: false,
     }),
     Layouts(),
     // https://github.com/vuetifyjs/vuetify-loader/tree/master/packages/vite-plugin#readme


### PR DESCRIPTION
Instead of using vuetify tabs, model different views as pages/routes. This is backwards-compatible with URL query parameters (e.g., `?tab=name`). Changes also include putting the dimensionality reduction into a web-worker, thereby no longer freezing the page when going to the meta items view.