### PR TITLE
Objection Refinement

### DIFF
--- a/src/components/CSVExporter.vue
+++ b/src/components/CSVExporter.vue
@@ -77,7 +77,7 @@
 
                         <template v-slot:item.filepath="{ item }">
                             <EvidenceCell :item="item"
-                                disable-context-menu
+                                prevent-right-click
                                 zoom-on-hover
                                 :height="60"
                                 :show-tag="false"

--- a/src/components/UserChip.vue
+++ b/src/components/UserChip.vue
@@ -1,0 +1,71 @@
+<template>
+    <div>
+        <v-tooltip v-if="user" :text="user.name" location="top" open-delay="300">
+            <template v-slot:activator="{ props }">
+                <v-chip v-bind="props"
+                    :variant="model ? 'flat' : 'outlined'"
+                    :class="{ 'text-caption': small, 'cursor-pointer': selectable }"
+                    @click="onClick"
+                    @pointerenter="onEnter"
+                    @pointerleave="onLeave"
+                    density="compact"
+                    :color="user.color">
+                    {{ short ? user.short : user.name }}
+                </v-chip>
+            </template>
+        </v-tooltip>
+    </div>
+</template>
+
+<script setup>
+    import { useApp } from '@/store/app';
+    import { onMounted, watch } from 'vue';
+
+    const app = useApp()
+
+    const model = defineModel({ type: Boolean, default: true })
+    const props = defineProps({
+        id: {
+            type: Number,
+            required: true
+        },
+        short: {
+            type: Boolean,
+            default: false
+        },
+        small: {
+            type: Boolean,
+            default: false
+        },
+        selectable: {
+            type: Boolean,
+            default: false
+        },
+    })
+
+    const emit = defineEmits(["click", "hover"])
+
+    const user = ref(null)
+
+    function read() {
+        user.value = app.getUser(props.id)
+        model.value = true
+    }
+
+    function onClick(event) {
+        if (props.selectable) {
+            model.value = !model.value
+        }
+        emit("click", props.id, event, model.value)
+    }
+    function onEnter(event) {
+        emit("hover", props.id, event)
+    }
+    function onLeave(event) {
+        emit("hover", null, event)
+    }
+
+    onMounted(read)
+
+    watch(() => props.id, read)
+</script>

--- a/src/components/dialogs/ItemEditor.vue
+++ b/src/components/dialogs/ItemEditor.vue
@@ -1,10 +1,10 @@
 <template>
-    <v-dialog v-model="model" width="95vw" style="overflow-y: auto;">
+    <v-dialog v-model="model" width="97vw" style="overflow-y: auto;">
         <v-card v-if="item" min-height="95vh" height="95vh">
             <v-card-text ref="wrapper" class="pa-0">
-                <div>
+                <div style="max-height: 40px;">
                     <div class="d-flex align-center justify-start">
-                        <div>
+                        <div v-if="mdAndUp">
                             <v-btn icon="mdi-arrow-left"
                                 density="compact"
                                 rounded="sm"
@@ -20,8 +20,8 @@
                                 :disabled="!hasNext"
                                 @click="emit('next-item')"/>
                         </div>
-                        <v-divider vertical></v-divider>
-                        <v-img v-if="item.teaser"
+                        <v-divider vertical v-if="mdAndUp"></v-divider>
+                        <v-img v-if="smAndUp && item.teaser"
                             :src="mediaPath('teaser', item.teaser)"
                             style="max-width: 80px; max-height: 40px;"
                             class="ml-2"
@@ -29,11 +29,11 @@
                             width="80"
                             height="40"/>
 
-                        <span style="max-width: 200px;" :title="item?.name" class="font-weight-bold ml-2 mr-4 text-dots">{{ item?.name }}</span>
+                        <span v-if="smAndUp" style="max-width: 200px;" :title="item?.name" class="font-weight-bold ml-2 mr-4 text-dots">{{ item?.name }}</span>
 
-                        <ExpertiseRating :item="item" :user="activeUserId" :key="'rate_'+item.id"/>
+                        <ExpertiseRating v-if="mdAndUp" :item="item" :user="activeUserId" :key="'rate_'+item.id"/>
 
-                        <v-divider vertical></v-divider>
+                        <v-divider vertical v-if="smAndUp"></v-divider>
                         <v-btn
                             density="compact"
                             variant="plain"
@@ -43,19 +43,21 @@
                             @click="showInfo = !showInfo"/>
 
                         <v-divider vertical></v-divider>
-                        <v-tabs v-model="tab" color="primary">
+                        <v-tabs v-model="tab" color="primary" density="compact" class="mt-1">
                             <v-tab text="Tags" value="tags"></v-tab>
                             <v-tab text="Evidence" value="evidence"></v-tab>
                             <v-tab text="Objections" value="objections"></v-tab>
                             <v-tab v-if="app.hasMetaItems" :text="capitalize(app.metaItemName+'s')" value="meta_items"></v-tab>
                         </v-tabs>
                     </div>
+
                     <div style="position: absolute; top: 5px; right: 5px;">
                         <v-btn
+                            :style="{ backgroundColor: lightMode ? 'white' : 'black' }"
+                            class="bordered-grey-light-thin"
                             icon="mdi-close"
                             color="error"
-                            rounded="sm"
-                            size="large"
+                            rounded
                             variant="text"
                             density="compact"
                             @click="model = false"/>
@@ -79,15 +81,15 @@
                             <p>{{ item?.description }}</p>
                         </div>
                     </div>
-                    <v-tabs-window v-model="tab" style="width: 100%; max-height: 90vh; overflow-y: auto;">
+                    <v-tabs-window v-model="tab" style="width: 100%; max-height: 91vh; overflow-y: auto;">
 
                         <v-tabs-window-item class="pa-4" value="tags" key="tags">
                             <ItemTagEditor ref="tedit"
                                 :key="'tags_'+item.id"
                                 :item="item"
                                 :data="tags"
-                                :width="width - (showInfo ? infoWidth + 30 : 50)"
-                                :height="height-50"
+                                :width="width-(showInfo ? infoWidth + 40 : 60)"
+                                :height="height-60"
                                 all-data-source="tags"
                                 @add="emit('add-tag')"
                                 @delete="emit('delete-tag')"/>
@@ -127,9 +129,15 @@
     import { storeToRefs } from 'pinia';
     import { capitalize, mediaPath } from '@/use/utility';
     import ObjectionTable from '../objections/ObjectionTable.vue';
+    import { useDisplay } from 'vuetify';
+    import { useSettings } from '@/store/settings';
 
     const app = useApp()
+    const settings = useSettings()
     const { activeUserId } = storeToRefs(app)
+    const { lightMode } = storeToRefs(settings)
+
+    const { smAndUp, mdAndUp } = useDisplay()
 
     const model = defineModel()
     const props = defineProps({

--- a/src/components/dialogs/MiniDialog.vue
+++ b/src/components/dialogs/MiniDialog.vue
@@ -2,7 +2,7 @@
     <v-dialog v-model="model"
         :min-width="minWidth"
         width="auto"
-        max-width="90%"
+        max-width="95%"
         elevation="8"
         :opacity="hideOverlay ? 0 : undefined"
         density="compact">
@@ -23,7 +23,7 @@
                 </div>
             </v-card-title>
 
-            <v-card-text class="pt-2 pb-2">
+            <v-card-text class="pt-2" :class="{ 'pb-4': noActions, 'pb-2': !noActions }">
                 <div style="max-height: 85vh; overflow-y: auto;">
                     <slot name="text">
                         {{ text }}

--- a/src/components/dialogs/NewObjectionDialog.vue
+++ b/src/components/dialogs/NewObjectionDialog.vue
@@ -12,11 +12,14 @@
     import MiniDialog from '../dialogs/MiniDialog.vue';
     import ObjectionWidget from '../objections/ObjectionWidget.vue';
     import { SOUND, useSounds } from '@/store/sounds';
+    import DM from '@/use/data-manager';
+    import { useToast } from 'vue-toastification';
 
     const model = defineModel();
     const emit = defineEmits(["cancel", "submit"])
 
     const app = useApp()
+    const toast = useToast()
     const sounds = useSounds()
 
     const objection = ref(null)
@@ -32,18 +35,38 @@
     }
     watch(model, function(newval) {
         if (newval) {
-            objection.value = {
-                code_id: app.currentCode,
-                user_id: app.activeUserId,
-                tag_id: app.addObjTag,
-                item_id: app.addObjItem,
-                status: OBJECTION_STATUS.OPEN,
-                explanation: "",
-                action: app.addObjType,
-                resolution: "",
-                resolved: null,
-                resolved_by: null
-            };
+            let ex = null
+
+            if (app.addObjItem) {
+                const all = DM.getDataItem("objections_items", app.addObjItem)
+                ex = all.find(d => {
+                    return d.resolved === null &&
+                        (app.addObjTag === null && !d.tag_id || d.tag_id === app.addObjTag)
+                })
+            } else if (app.addEvTag) {
+                const all = DM.getDataItem("objections_tags", app.addEvTag)
+                ex = all.find(d => d.resolved === null && d.item_id === null)
+            }
+
+            if (ex) {
+                toast.info("objection alread exists", { timeout: 2000 })
+                app.setShowObjection(ex.id)
+                objection.value = null
+                cancel()
+            } else {
+                objection.value = {
+                    code_id: app.currentCode,
+                    user_id: app.activeUserId,
+                    tag_id: app.addObjTag,
+                    item_id: app.addObjItem,
+                    status: OBJECTION_STATUS.OPEN,
+                    explanation: "",
+                    action: app.addObjType,
+                    resolution: "",
+                    resolved: null,
+                    resolved_by: null
+                }
+            }
         } else {
             objection.value = null
         }

--- a/src/components/dialogs/NewObjectionDialog.vue
+++ b/src/components/dialogs/NewObjectionDialog.vue
@@ -39,13 +39,17 @@
 
             if (app.addObjItem) {
                 const all = DM.getDataItem("objections_items", app.addObjItem)
-                ex = all.find(d => {
-                    return d.resolved === null &&
+                if (all) {
+                    ex = all.find(d => {
+                        return d.resolved === null &&
                         (app.addObjTag === null && !d.tag_id || d.tag_id === app.addObjTag)
-                })
+                    })
+                }
             } else if (app.addEvTag) {
                 const all = DM.getDataItem("objections_tags", app.addEvTag)
-                ex = all.find(d => d.resolved === null && d.item_id === null)
+                if (all) {
+                    ex = all.find(d => d.resolved === null && d.item_id === null)
+                }
             }
 
             if (ex) {

--- a/src/components/evidence/EvidenceHeatmap.vue
+++ b/src/components/evidence/EvidenceHeatmap.vue
@@ -129,11 +129,10 @@
                             <EvidenceCell v-for="(e, idx) in selectedItem.evidence" :key="e.id+'_details'"
                                 style="display: inline-block;"
                                 :item="e"
-                                @select="app.setShowEvidence(
-                                    e.id,
-                                    selectedItem.evidence.map(dd => dd.id),
-                                    idx
-                                )"
+                                prevent-click
+                                zoom-on-hover
+                                :evidence-list="selectedItem.evidence.map(dd => dd.id)"
+                                :index="idx"
                                 :width="150"
                                 :height="150"/>
                         </div>

--- a/src/components/evidence/EvidenceWidget.vue
+++ b/src/components/evidence/EvidenceWidget.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="d-flex flex-column align-center">
+    <div class="d-flex flex-column align-center" style="max-width: 100%;">
 
         <video v-if="isVideoFile"
             :src="imagePreview ? imagePreview : mediaPath('evidence', item.filepath)"

--- a/src/components/evidence/EvidenceWidget.vue
+++ b/src/components/evidence/EvidenceWidget.vue
@@ -284,6 +284,17 @@
     }
 
     function getEvidenceObj() {
+
+        // must have a tag
+        if (!tagId.value) {
+            return null
+        }
+
+        // must have a description or attached image/video
+        if (!props.item.filepath && !file.value && !desc.value) {
+            return null
+        }
+
         const obj = {
             description: desc.value,
             filepath: props.item.filepath,

--- a/src/components/evidence/ItemEvidenceEditor.vue
+++ b/src/components/evidence/ItemEvidenceEditor.vue
@@ -46,9 +46,11 @@
                         :width="width*emul"
                         :height="height*emul"
                         :scale-factor="scaleFactor"
-                        :selected="hoverTag === e.tag_id || selectedItem !== null && selectedItem.id === e.id"
-                        @select="selectEvidence"
+                        :highlight="hoverTag === e.tag_id || selectedItem !== null && selectedItem.id === e.id"
+                        @click="selectEvidence"
                         @delete="checkOnDelete"
+                        zoom-on-hover
+                        prevent-click
                         allow-delete
                         allow-copy/>
                 </v-sheet>

--- a/src/components/evidence/ItemEvidenceRow.vue
+++ b/src/components/evidence/ItemEvidenceRow.vue
@@ -32,13 +32,7 @@
 
     <div class="d-flex flex-wrap">
         <v-sheet v-for="e in evidence" :key="'ev_t_'+e.id" class="pa-1 mr-2" :width="height">
-
-            <EvidenceCell
-                :item="e"
-                :width="width"
-                :height="height"
-                @select="app.setShowEvidence(e.id)"/>
-
+            <EvidenceCell :item="e" :width="width" :height="height"/>
         </v-sheet>
 
         <v-btn v-if="allowAdd"

--- a/src/components/games/TriviaGame.vue
+++ b/src/components/games/TriviaGame.vue
@@ -433,9 +433,13 @@
                 return OBJECTION_ACTIONS.DISCUSS
             default:
                 if (wasCorrectAnswer(index, answer)) {
-                    return OBJECTION_ACTIONS.REMOVE
+                    return questions.value[index].exists ?
+                        OBJECTION_ACTIONS.REMOVE :
+                        OBJECTION_ACTIONS.ADD
                 }
-                return OBJECTION_ACTIONS.ADD
+                return questions.value[index].exists ?
+                    OBJECTION_ACTIONS.ADD :
+                    OBJECTION_ACTIONS.REMOVE
         }
     }
     function getBorderColorResult(index, answer) {
@@ -567,30 +571,38 @@
         switch (type) {
             case QTYPES.ITEM_HAS_TAG:{
                 const tag = randomLeafTags(1, numAnswers.value+1)
-                const hasTag = randomBool()
-                const target = hasTag ?
+                const has = randomBool()
+                const target = has ?
                     randomItemsWithTags(tag.id, 1) :
                     randomItemsWithoutTags(tag.id, 1)
-                const other = hasTag ?
+                const other = has ?
                     randomItemsWithoutTags(tag.id, numAnswers.value-1) :
                     randomItemsWithTags(tag.id, numAnswers.value-1)
 
                 return {
                     type: type,
-                    text: `Which ${app.itemName} ${hasTag ? 'has' : 'does <b>not</b> have'} the tag <b>${tag.name}</b>?`,
+                    text: `Which ${app.itemName} ${has ? 'has' : 'does <b class="text-decoration-underline">not</b> have'} the tag <b>${tag.name}</b>?`,
                     tag: tag,
+                    exists: has,
                     itemChoices: randomShuffle([target].concat(other)),
                     answer: { item: target }
                 }
             }
             case QTYPES.TAG_HAS_ITEM: {
                 const item = randomItems(1, numAnswers.value+1)
-                const tag = randomChoice(item.allTags, 1)
-                const tagOther = randomLeafTags(numAnswers.value-1, 1, item.allTags.map(t => t.id))
+                const has = randomBool()
+                const tag = has ?
+                    randomChoice(item.allTags, 1) :
+                    randomLeafTags(1, 5, item.allTags.map(t => t.id))
+                const tagOther = has ?
+                    randomLeafTags(numAnswers.value-1, 1, item.allTags.map(t => t.id)) :
+                    randomChoice(item.allTags, numAnswers.value-1)
+
                 return {
                     type: type,
-                    text: `Which <b>tag</b> does this ${app.itemName} have?`,
+                    text: `Which <b>tag</b> does this ${app.itemName} ${has ? '' : '<b class="text-decoration-underline">not</b>' } have?`,
                     item: item,
+                    exists: has,
                     tagChoices: randomShuffle([tag].concat(tagOther)),
                     answer: { tag: tag }
                 }

--- a/src/components/items/ItemSummary.vue
+++ b/src/components/items/ItemSummary.vue
@@ -31,7 +31,9 @@
 
         <div v-if="showEvidence" class="mt-1 d-flex flex-wrap">
             <EvidenceCell v-for="(e, idx) in evidence" :key="'ev_'+e.id"
-                @select="app.setShowEvidence(e.id, evidenceIds, idx)"
+                :index="idx"
+                zoom-on-hover
+                :evidence-list="evidenceIds"
                 :width="evidenceSize"
                 :height="evidenceSize"
                 :item="e"/>

--- a/src/components/meta_items/MetaItemTile.vue
+++ b/src/components/meta_items/MetaItemTile.vue
@@ -63,11 +63,9 @@
                 :key="'e_'+e.id"
                 :item="e"
                 :height="100"
-                @select="app.setShowEvidence(
-                    e.id,
-                    evidence.map(dd => dd.id),
-                    idx
-                )"/>
+                :index="idx"
+                zoom-on-hover
+                :evidence-list="evidence.map(dd => dd.id)"/>
         </div>
     </div>
     <div class="mt-1 d-flex text-caption">

--- a/src/components/meta_items/MetaItemWidget.vue
+++ b/src/components/meta_items/MetaItemWidget.vue
@@ -82,14 +82,16 @@
                         class="mb-1 mr-1"
                         :width="evidenceSize"
                         :height="evidenceSize"
-                        :selected="selectedEvs.has(e.id)"
-                        disable-context-menu
+                        :highlight="selectedEvs.has(e.id)"
+                        zoom-on-hover
+                        prevent-right-click
                         @right-click="app.setShowEvidence(
                             e.id,
                             evidence.map(dd => dd.id),
                             idx
                         )"
-                        @select="toggleEvidence(e.id)"/>
+                        prevent-click
+                        @click="toggleEvidence(e.id)"/>
                 </div>
             </div>
         </div>

--- a/src/components/objections/ObjectionTable.vue
+++ b/src/components/objections/ObjectionTable.vue
@@ -35,7 +35,14 @@
             hide-details
             single-line/>
 
-        <v-data-table :headers="headers" :items="filtered" :search="search" density="compact" :key="'obj_'+time" style=" width: 100%;">
+        <v-data-table
+            :headers="headers"
+            :items="filtered"
+            :search="search"
+            v-model:page="page"
+            density="compact"
+            :key="'obj_'+time"
+            style=" width: 100%;">
             <template v-slot:item="{ item }">
                 <tr :class="item.edit ? 'edit data-row' : 'data-row'" @click="openIfNotEdit(item.id, item.edit)">
                     <td v-if="hasHeader('edit')">
@@ -191,6 +198,8 @@
     const time = ref(0)
     const search = ref("")
     const objections = ref([])
+
+    const page = ref(1)
 
     const showStatus = reactive({})
     showStatus[OBJECTION_STATUS.OPEN] = true

--- a/src/components/objections/ObjectionWidget.vue
+++ b/src/components/objections/ObjectionWidget.vue
@@ -1,138 +1,193 @@
 <template>
-    <div style="width: fit-content; max-width: 90vw;">
-        <div class="d-flex justify-center align-center mb-2">
-            <v-chip
-                :variant="action === OBJECTION_ACTIONS.DISCUSS ? 'flat' : 'outlined'"
-                :color="action === OBJECTION_ACTIONS.DISCUSS ? getActionColor(action) : 'default'"
-                @click="setAction(OBJECTION_ACTIONS.DISCUSS)">
-                {{ getActionName(OBJECTION_ACTIONS.DISCUSS) }}
-            </v-chip>
-            <v-chip
-                class="ml-1 mr-1"
-                :variant="action === OBJECTION_ACTIONS.ADD ? 'flat' : 'outlined'"
-                :color="action === OBJECTION_ACTIONS.ADD ? getActionColor(action) : 'default'"
-                :disabled="!canAdd"
-                @click="setAction(OBJECTION_ACTIONS.ADD)">
-                {{ getActionName(OBJECTION_ACTIONS.ADD) }}
-            </v-chip>
-            <v-chip
-                :variant="action === OBJECTION_ACTIONS.REMOVE ? 'flat' : 'outlined'"
-                :color="action === OBJECTION_ACTIONS.REMOVE ? getActionColor(action) : 'default'"
-                :disabled="!canRemove"
-                @click="setAction(OBJECTION_ACTIONS.REMOVE)">
-                {{ getActionName(OBJECTION_ACTIONS.REMOVE) }}
-            </v-chip>
-        </div>
+
+    <div :style="{ maxWidth: mdAndUp ? '900px' : '85vw' }">
+        <div class="d-flex" style="max-width: 100%;" :class="{
+            'align-stretch': !smAndDown,
+            'justify-space-between': !smAndDown,
+            'flex-column': smAndDown,
+            'align-center': smAndDown,
+        }">
+
+            <div style="width: max-content; max-height: 80vh; overflow-y: auto;">
+
+                <div class="text-caption mb-2"><b>owner:</b> {{ app.getUserName(item.user_id) }}</div>
+
+                <div class="d-flex justify-center align-center mb-3">
+                    <v-chip
+                        :variant="action === OBJECTION_ACTIONS.DISCUSS ? 'flat' : 'outlined'"
+                        :color="action === OBJECTION_ACTIONS.DISCUSS ? getActionColor(action) : 'default'"
+                        @click="setAction(OBJECTION_ACTIONS.DISCUSS)">
+                        {{ getActionName(OBJECTION_ACTIONS.DISCUSS) }}
+                    </v-chip>
+                    <v-chip
+                        class="ml-1 mr-1"
+                        :variant="action === OBJECTION_ACTIONS.ADD ? 'flat' : 'outlined'"
+                        :color="action === OBJECTION_ACTIONS.ADD ? getActionColor(action) : 'default'"
+                        :disabled="!canAdd"
+                        @click="setAction(OBJECTION_ACTIONS.ADD)">
+                        {{ getActionName(OBJECTION_ACTIONS.ADD) }}
+                    </v-chip>
+                    <v-chip
+                        :variant="action === OBJECTION_ACTIONS.REMOVE ? 'flat' : 'outlined'"
+                        :color="action === OBJECTION_ACTIONS.REMOVE ? getActionColor(action) : 'default'"
+                        :disabled="!canRemove"
+                        @click="setAction(OBJECTION_ACTIONS.REMOVE)">
+                        {{ getActionName(OBJECTION_ACTIONS.REMOVE) }}
+                    </v-chip>
+                </div>
 
 
-        <v-select v-model="tagId"
-            :readonly="!canEdit"
-            density="compact"
-            label="related tag"
-            class="tiny-font text-caption mb-1"
-            :items="tags"
-            item-title="name"
-            item-value="id"
-            hide-details
-            hide-spin-buttons>
+                <v-select v-model="tagId"
+                    :readonly="!canEdit"
+                    density="compact"
+                    label="related tag"
+                    class="tiny-font text-caption mb-1"
+                    :items="tags"
+                    item-title="name"
+                    item-value="id"
+                    :clearable="canEdit"
+                    hide-details
+                    hide-spin-buttons>
 
-            <template #prepend>
-                <v-tooltip :text="tagDesc" location="top" open-delay="100">
-                    <template v-slot:activator="{ props }">
-                        <v-icon v-bind="props">mdi-help-circle-outline</v-icon>
+                    <template #prepend>
+                        <v-tooltip :text="tagDesc" location="top" open-delay="100">
+                            <template v-slot:activator="{ props }">
+                                <v-icon v-bind="props">mdi-help-circle-outline</v-icon>
+                            </template>
+                        </v-tooltip>
                     </template>
-                </v-tooltip>
-            </template>
 
-        </v-select>
+                    <template #item="{ item }">
+                        <TagText :tag="item" prevent-select prevent-hover/>
+                    </template>
 
-        <div class="d-flex align-center mb-1">
-            <ItemTeaser v-if="itemId" :id="itemId" :width="80" :height="40"/>
-            <v-card v-else width="80" height="40"  color="surface-light" class="d-flex align-center justify-center prevent-select">
-                <v-icon>mdi-image-area</v-icon>
-            </v-card>
-            <v-select v-model="itemId"
-                :readonly="!canEdit"
-                density="compact"
-                :label="'related '+app.itemName"
-                class="tiny-font text-caption ml-1"
-                :items="items"
-                item-title="name"
-                item-value="id"
-                hide-details
-                hide-spin-buttons/>
-        </div>
+                </v-select>
 
-        <v-textarea v-model="exp"
-            density="compact"
-            label="explanation"
-            hide-details
-            hide-spin-buttons
-            :style="{ minWidth: smAndUp ? '400px' : '275px' }"/>
+                <div class="d-flex align-center mb-1">
+                    <ItemTeaser v-if="itemId" :id="itemId" :width="80" :height="40"/>
+                    <v-card v-else width="80" height="40"  color="surface-light" class="d-flex align-center justify-center prevent-select">
+                        <v-icon>mdi-image-area</v-icon>
+                    </v-card>
+                    <v-select v-model="itemId"
+                        :readonly="!canEdit"
+                        density="compact"
+                        :label="'related '+app.itemName"
+                        class="tiny-font text-caption ml-1"
+                        :items="items"
+                        item-title="name"
+                        item-value="id"
+                        :clearable="canEdit"
+                        hide-details
+                        hide-spin-buttons/>
+                </div>
+
+                <v-textarea v-model="exp"
+                    density="compact"
+                    label="explanation"
+                    hide-details
+                    hide-spin-buttons
+                    :readonly="!canEdit"
+                    :style="{ minWidth: smAndUp ? '400px' : '275px' }"/>
 
 
-        <v-btn v-if="!item.resolved"
-            rounded="sm"
-            class="mt-1"
-            block
-            variant="tonal"
-            :color="canAct ? 'primary' : 'default'"
-            density="comfortable"
-            :disabled="!canAct"
-            @click="showResolve = !showResolve">
-            {{ showResolve ? 'cancel' : '' }} resolve
-        </v-btn>
-
-        <div v-if="item.resolved" class="mt-2">
-            <div class="d-flex align-center justify-space-between">
-                <b>resolved by: </b>
-                <span class="ml-1">{{ app.getUserName(item.resolved_by) }}</span>
-            </div>
-            <div class="d-flex align-center justify-space-between mb-1">
-                <b>status: </b>
-                <span class="ml-1 d-flex align-center">
-                    <v-icon :color="getObjectionStatusColor(item.status)" class="mr-1">{{ getObjectionStatusIcon(item.status) }}</v-icon>
-                    <span>{{ getObjectionStatusName(item.status) }}</span>
-                </span>
-            </div>
-            <v-textarea
-                :model-value="item.resolution"
-                density="compact"
-                label="resolution"
-                readonly
-                hide-details
-                hide-spin-buttons
-                :style="{ minWidth: smAndUp ? '400px' : '275px' }"/>
-        </div>
-        <div v-else-if="canAct && showResolve" class="mt-4">
-            <div class="d-flex align-center justify-space-between mb-1" style="width: 100%;">
-                <b>{{ getActionName(item.action) }} tag: </b>
-                <TagText v-if="tagId" :id="tagId" class="ml-1"/>
-            </div>
-            <v-textarea v-model="res"
-                density="compact"
-                label="resolution"
-                hide-details
-                hide-spin-buttons
-                :style="{ minWidth: smAndUp ? '400px' : '275px' }"/>
-
-            <div class="mt-1 d-flex align-center justify-space-between">
-                <v-btn
-                    :color="canEdit && res ? 'error' : 'default'"
-                    :disabled="!canEdit || !res"
-                    @click="performAction(false)"
-                    style="width: 49%;"
-                    density="comfortable">
-                    deny
+                <v-btn v-if="!item.resolved"
+                    rounded="sm"
+                    class="mt-1"
+                    block
+                    variant="tonal"
+                    :color="canAct ? (showResolve ? 'warning' : 'primary') : 'default'"
+                    density="comfortable"
+                    :disabled="!canAct"
+                    @click="showResolve = !showResolve">
+                    {{ showResolve ? 'cancel' : '' }} resolve
                 </v-btn>
-                <v-btn
-                    :color="canEdit && res ? 'primary' : 'default'"
-                    :disabled="!canEdit || !res"
-                    @click="performAction(true)"
-                    style="width: 49%;"
-                    density="comfortable">
-                    approve
-                </v-btn>
+
+                <div v-if="item.resolved" class="mt-2">
+                    <div class="d-flex align-center justify-space-between">
+                        <b>resolved by: </b>
+                        <span class="ml-1">{{ app.getUserName(item.resolved_by) }}</span>
+                    </div>
+                    <div class="d-flex align-center justify-space-between mb-1">
+                        <b>status: </b>
+                        <span class="ml-1 d-flex align-center">
+                            <v-icon :color="getObjectionStatusColor(item.status)" class="mr-1">{{ getObjectionStatusIcon(item.status) }}</v-icon>
+                            <span>{{ getObjectionStatusName(item.status) }}</span>
+                        </span>
+                    </div>
+                    <v-textarea
+                        :model-value="item.resolution"
+                        density="compact"
+                        label="resolution"
+                        readonly
+                        hide-details
+                        hide-spin-buttons
+                        :style="{ minWidth: smAndUp ? '400px' : '275px' }"/>
+                </div>
+                <div v-else-if="canAct && showResolve" class="mt-4">
+                    <div class="d-flex align-center justify-space-between mb-1" style="width: 100%;">
+                        <b>{{ getActionName(item.action) }} tag: </b>
+                        <TagText v-if="tagId" :id="tagId" class="ml-1"/>
+                    </div>
+                    <v-textarea v-model="res"
+                        density="compact"
+                        label="resolution"
+                        hide-details
+                        hide-spin-buttons
+                        :style="{ minWidth: smAndUp ? '400px' : '275px' }"/>
+
+                    <div class="mt-1 d-flex align-center justify-space-between">
+                        <v-btn
+                            :color="canEdit && res ? 'error' : 'default'"
+                            :disabled="!canEdit || !res"
+                            @click="performAction(false)"
+                            style="width: 49%;"
+                            density="comfortable">
+                            deny
+                        </v-btn>
+                        <v-btn
+                            :color="canEdit && res ? 'primary' : 'default'"
+                            :disabled="!canEdit || !res"
+                            @click="performAction(true)"
+                            style="width: 49%;"
+                            density="comfortable">
+                            approve
+                        </v-btn>
+                    </div>
+                </div>
+            </div>
+
+            <div v-if="showResolve || hasCodersOrEvidence"
+                class="d-flex flex-column justify-space-between"
+                :class="{ 'ml-4': !smAndDown, 'mt-4': smAndDown }"
+                :style="{ maxWidth: mdAndUp ? '50%' : '100%' }"
+                style="text-align: center; min-width: 200px; max-height: 80vh; overflow-y: auto;">
+
+                <div v-if="hasCodersOrEvidence">
+                    <div class="text-decoration-underline mb-1">coders</div>
+                    <div class="d-flex flex-wrap justify-center">
+                        <UserChip v-for="uid in coders" :id="uid" class="mr-1 mb-1" small short/>
+                    </div>
+                    <div class="mt-3 mb-1 text-decoration-underline">evidence</div>
+                    <div class="d-flex flex-wrap justify-center">
+                        <EvidenceCell v-for="e in evidence" :item="e" zoom-on-hover/>
+                    </div>
+                </div>
+
+                <div v-if="!item.resolved && showResolve && itemObj">
+                    <div v-if="action === OBJECTION_ACTIONS.REMOVE && evidence.length > 0">
+                        remove related evidence?
+                    </div>
+                    <div v-else-if="action === OBJECTION_ACTIONS.ADD">
+                        <div><b>attach new evidence</b></div>
+                        <EvidenceWidget v-if="newEv"
+                            ref="evw"
+                            emit-only
+                            tag-fixed
+                            :item="newEv"
+                            :allowed-tags="tags"
+                            :max-image-height="250"/>
+                    </div>
+                </div>
             </div>
         </div>
 
@@ -166,20 +221,23 @@
     import { getActionColor, getActionName, getObjectionStatusColor, getObjectionStatusIcon, getObjectionStatusName, OBJECTION_ACTIONS, OBJECTION_STATUS, useApp } from '@/store/app'
     import { useTimes } from '@/store/times'
     import DM from '@/use/data-manager'
-    import { addDataTags, addObjections, deleteDataTags, updateObjections } from '@/use/data-api'
+    import { addDataTags, addEvidence, addEvidenceImage, addObjections, deleteDataTags, updateObjections } from '@/use/data-api'
     import { storeToRefs } from 'pinia'
     import { watch, ref, onMounted, computed } from 'vue'
     import { useToast } from 'vue-toastification'
     import TagText from '../tags/TagText.vue'
     import ItemTeaser from '../items/ItemTeaser.vue'
     import { useDisplay } from 'vuetify'
+    import UserChip from '../UserChip.vue'
+    import EvidenceCell from '../evidence/EvidenceCell.vue'
+    import EvidenceWidget from '../evidence/EvidenceWidget.vue'
 
     const times = useTimes()
     const app = useApp()
     const toast = useToast()
 
     const { allowEdit } = storeToRefs(app)
-    const { smAndUp } = useDisplay()
+    const { smAndDown, smAndUp, mdAndUp } = useDisplay()
 
     const props = defineProps({
         item: {
@@ -189,6 +247,8 @@
     })
 
     const emit = defineEmits(["update", "action"])
+
+    const evw = ref(null)
 
     const action = ref(null)
     const exp = ref("")
@@ -204,8 +264,14 @@
     const items = ref([])
     const itemObj = ref(null)
 
+    const coders = ref([])
+    const evidence = ref([])
+
+    const hasCodersOrEvidence = computed(() => coders.value.length > 0 || evidence.value.length > 0)
     const existing = computed(() => props.item.id !== null && props.item.id !== undefined && props.item.id > 0)
     const isOpen = computed(() => props.item.status === OBJECTION_STATUS.OPEN)
+
+    const newEv = ref(null)
 
     const canEdit = computed(() => allowEdit.value && isOpen.value)
     const canAct = computed(() => {
@@ -240,21 +306,60 @@
         action.value = value
     }
 
-    function readTags() {
+    function readMisc() {
+        if (itemObj.value === null) {
+            coders.value = []
+            evidence.value = []
+            newEv.value = null
+        } else {
+            if (tagId.value === null) {
+                coders.value = itemObj.value.coders
+                evidence.value = itemObj.value.evidence
+                newEv.value = null
+            } else {
+                coders.value = itemObj.value.tags
+                    .filter(d => tagId.value === null || d.tag_id === tagId.value)
+                    .map(d => d.created_by)
+
+                evidence.value = itemObj.value.evidence
+                    .filter(d => tagId.value === null || d.tag_id === tagId.value)
+
+                newEv.value = {
+                    code_id: app.currentCode,
+                    created_by: app.activeUserId,
+                    created: Date.now(),
+                    tag_id: tagId.value,
+                    item_id: itemId.value,
+                    filepath: null,
+                    description: "",
+                }
+            }
+        }
+    }
+
+    function readTags(update=true) {
         itemObj.value = itemId.value !== null ? DM.getDataItem("items", itemId.value) : null
         if (itemObj.value !== null && action.value === OBJECTION_ACTIONS.REMOVE) {
-            tags.value = DM.getDataBy("tags", t => t.is_leaf === 1 && itemObj.value.allTags.find(d => d.id === t.id))
+            tags.value = DM.getDataBy("tags", t => t.is_leaf === 1 && (!isOpen.value || itemObj.value.allTags.find(d => d.id === t.id)))
         } else {
             tags.value = DM.getData("tags", false)
         }
+        if (update)  readMisc()
     }
-    function readItems() {
-        if (action.value === OBJECTION_ACTIONS.REMOVE && tagId.value !== null) {
-            items.value = DM.getDataBy("items", d => d.allTags.find(t => t.id === tagId.value))
-                .map(d => ({ id: d.id, name: d.name }))
+
+    function readItems(update=true) {
+        if (!isOpen.value && itemObj.value) {
+            items.value = [{ id: itemObj.value.id, name: itemObj.value.name }]
         } else {
-            items.value = DM.getData("items", false).map(d => ({ id: d.id, name: d.name }))
+            if (action.value === OBJECTION_ACTIONS.REMOVE && tagId.value !== null) {
+                items.value = DM.getDataBy("items", d => d.allTags.find(t => t.id === tagId.value))
+                    .map(d => ({ id: d.id, name: d.name }))
+            } else {
+                items.value = DM.getData("items", false).map(d => ({ id: d.id, name: d.name }))
+            }
         }
+
+        if (update)  readMisc()
     }
 
     async function performAction(apply) {
@@ -275,7 +380,9 @@
 
             const tid = props.item.tag_id
 
-            let updateObj = false, updateDts = false;
+            const addEv = evw.value ? evw.value.getEvidenceObj() : null
+
+            let updateObj = false, updateDts = false, updateEv = false;
             switch(props.item.action) {
                 case OBJECTION_ACTIONS.DISCUSS:
                     updateObj = true
@@ -302,6 +409,20 @@
                     if (dts.length > 0) {
                         await addDataTags(dts)
                         toast.success(`added ${dts.length} user tag(s)`)
+                        if (addEv) {
+                            // add image first if there is one
+                            if (addEv.file) {
+                                const resp = await addEvidenceImage(addEv.filename, addEv.file)
+                                addEv.filepath = resp.name
+                                delete addEv.file
+                                delete addEv.filename
+                                console.log("added evidence image")
+                            }
+                            // add the evidence itself
+                            await addEvidence([addEv])
+                            console.log("added evidence")
+                            updateEv = true
+                        }
                         updateObj = true
                         updateDts = true
                     } else {
@@ -329,6 +450,10 @@
 
             if (updateDts) {
                 times.needsReload("datatags")
+            }
+
+            if (updateEv) {
+                times.needsReload("evidence")
             }
 
             if (updateObj) {
@@ -412,15 +537,16 @@
     }
 
     function read() {
-        action.value = props.item.action;
-        exp.value = props.item.explanation;
-        res.value = props.item.resolution;
-        tagId.value = props.item.tag_id;
-        itemId.value = props.item.item_id;
+        action.value = props.item.action
+        exp.value = props.item.explanation
+        res.value = props.item.resolution
+        tagId.value = props.item.tag_id
+        itemId.value = props.item.item_id
         tagName.value = tagId.value ? DM.getDataItem("tags_name", tagId.value) : ""
         tagDesc.value = tagId.value ? DM.getDataItem("tags_desc", tagId.value) : ""
-        readTags()
-        readItems()
+        readTags(false)
+        readItems(false)
+        readMisc()
     }
 
     onMounted(read)
@@ -430,7 +556,7 @@
     watch(itemId, readTags)
     watch(tagId, readItems)
     watch(action, function() {
-        readTags()
+        readTags(false)
         readItems()
     })
 </script>

--- a/src/components/tags/ItemTagEditor.vue
+++ b/src/components/tags/ItemTagEditor.vue
@@ -135,7 +135,7 @@
     import TagTiles from '@/components/tags/TagTiles.vue';
     import { onMounted, ref, computed, watch } from 'vue';
     import { useToast } from "vue-toastification";
-    import { useApp } from '@/store/app';
+    import { OBJECTION_ACTIONS, useApp } from '@/store/app';
     import { CTXT_OPTIONS, useSettings } from '@/store/settings'
     import DM from '@/use/data-manager';
     import { storeToRefs } from 'pinia';
@@ -288,7 +288,7 @@
                 "tag", id,
                 mx, my,
                 tag.name,
-                { item: props.item.id },
+                { item: props.item.id, action: OBJECTION_ACTIONS.REMOVE },
                 CTXT_OPTIONS.items_tagged
             );
         } else {
@@ -296,7 +296,7 @@
                 "tag", id,
                 mx, my,
                 tag.name,
-                { item: props.item.id },
+                { item: props.item.id, action: OBJECTION_ACTIONS.ADD },
                 CTXT_OPTIONS.items_untagged
             );
         }

--- a/src/store/app.js
+++ b/src/store/app.js
@@ -89,6 +89,14 @@ export function getObjectionStatusColor(status) {
     }
 }
 
+const GUEST_USER = Object.freeze({
+    name: "guest",
+    id: -1,
+    role: "guest",
+    short: "gst",
+    color: "black"
+})
+
 export const useApp = defineStore('app', {
     state: () => ({
         static: __APP_STATIC__,
@@ -256,7 +264,7 @@ export const useApp = defineStore('app', {
         setActiveUser(id) {
             if (id !== this.activeUserId) {
                 const usr = this.globalUsers.find(d => d.id === id)
-                this.activeUser = !usr || id < 0 ? { name: "guest", id: -1, role: "guest", short: "gst" } : usr
+                this.activeUser = !usr || id < 0 ? GUEST_USER : usr
                 this.activeUserId = this.activeUser ? this.activeUser.id : null;
                 if (this.activeUserId < 0 || this.activeUser.role === "guest") {
                     this.showAllUsers = true;
@@ -281,23 +289,28 @@ export const useApp = defineStore('app', {
             return ds ? ds.name : null;
         },
 
+        getUser(id) {
+            const u = this.globalUsers.find(d => d.id === id);
+            return u ? u : null
+        },
+
         hasUserName(name) {
             return this.globalUsers.find(d => d.name === name) !== undefined
         },
 
         getUserName(id) {
             const u = this.globalUsers.find(d => d.id === id);
-            return u ? u.name : "Guest";
+            return u ? u.name : GUEST_USER.name
         },
 
         getUserShort(id) {
             const u = this.globalUsers.find(d => d.id === id);
-            return u ? u.short : "gst";
+            return u ? u.short : GUEST_USER.short
         },
 
         getUserColor(id) {
             const u = this.globalUsers.find(d => d.id === id);
-            return u ? u.color : "black";
+            return u ? u.color : GUEST_USER.color
         },
 
         setActiveCode(id) {


### PR DESCRIPTION
Refine objections in the frontend:

- Make sure no duplicate objections are created by always looking at existing objections beforehand and opening the matching one instead
-  Make sure the objection table stays on the current page when updating
- Added tag context actions in the objection widget
-  Fixed wrong objection action being selected for trivia when the question is negated